### PR TITLE
Proposed fallback method for Datatypes not of type Float64, BigFloat and their Complex counterparts

### DIFF
--- a/src/roots.jl
+++ b/src/roots.jl
@@ -49,7 +49,7 @@ function complexroots(cfs::Vector{T}) where T<:Union{BigFloat,Complex{BigFloat}}
 end
 
 complexroots(neg::Vector, pos::Vector) =
-    complexroots([reverse(chop(neg,10*eps()), dims=1);pos])
+    complexroots([reverse(chop(neg,10eps()), dims=1);pos])
 complexroots(f::Fun{Laurent{DD,RR}}) where {DD,RR} =
     mappoint.(Ref(Circle()), Ref(domain(f)),
         complexroots(f.coefficients[2:2:end],f.coefficients[1:2:end]))

--- a/src/roots.jl
+++ b/src/roots.jl
@@ -30,6 +30,9 @@ end
 #         end
 #     end
 # else
+complexroots(cfs::Vector{T}) where T = 
+    sort(eigvals(companion_matrix(chop(cfs, 10*eps(T)))), lt = (x, y) -> real(x) < real(y) ? true : (real(x) > real(y) ? false : (imag(x) < imag(y) ? true : false)), rev=true)
+
 complexroots(cfs::Vector{T}) where {T<:Union{Float64,ComplexF64}} =
     hesseneigvals(companion_matrix(chop(cfs,10eps())))
 # end
@@ -46,7 +49,7 @@ function complexroots(cfs::Vector{T}) where T<:Union{BigFloat,Complex{BigFloat}}
 end
 
 complexroots(neg::Vector, pos::Vector) =
-    complexroots([reverse(chop(neg,10eps()), dims=1);pos])
+    complexroots([reverse(chop(neg,10*eps()), dims=1);pos])
 complexroots(f::Fun{Laurent{DD,RR}}) where {DD,RR} =
     mappoint.(Ref(Circle()), Ref(domain(f)),
         complexroots(f.coefficients[2:2:end],f.coefficients[1:2:end]))
@@ -56,9 +59,9 @@ complexroots(f::Fun{Taylor{DD,RR}}) where {DD,RR} =
 
 
 function roots(f::Fun{Laurent{DD,RR}}) where {DD,RR}
-    irts=filter!(z->in(z,Circle()),complexroots(Fun(Laurent(Circle()),f.coefficients)))
+    irts=filter!(z->in(z,Circle(real(eltype(z)))),complexroots(Fun(Laurent(Circle()),f.coefficients)))
     if length(irts)==0
-        Complex{Float64}[]
+        irts
     else
         rts=fromcanonical.(f, tocanonical.(Ref(Circle()), irts))
         if isa(domain(f),PeriodicSegment)


### PR DESCRIPTION
Hi, 

I needed to do division between two Laurent functions using the _Double64_ datatype from _DoubleFloats.jl_. I kept running into issues because the _complexroots_ function only had methods for _Float64_, _BigFloat_ and their Complex counterparts. So I here propose a more general fallback method which I have tested and works for _Double64_. 

The _sort_ is added ontop of the _eigvals_ call so that the returned eigenvalues are in the same order as those returned from _hesseneigvals_.

Furthermore inside the _roots_ function I have added the type inside the _Circle_ of the _filter!_ call otherwise there was some issues with domains.

Finally, in the _if_-statement of _roots_, the returned vector should not be hardcoded to be a _Complex{Float64}_ but perhaps _irts_ (as I have done) or someother way to make it more general.