### PR TITLE
mod2pi in tocanonical

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunFourier"
 uuid = "59844689-9c9d-51bf-9583-5b794ec66d30"
-version = "0.2.14"
+version = "0.2.15"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Domains/Circle.jl
+++ b/src/Domains/Circle.jl
@@ -43,14 +43,18 @@ convert(::Type{Circle{T,V}},::AnyDomain) where {T<:Number,V<:Real} = Circle{T,V}
 convert(::Type{IT},::AnyDomain) where {IT<:Circle} = Circle(NaN,NaN)
 
 
+function _tocanonical(v)
+	θ = atan(v[2]-0.0, v[1])  # -0.0 to get branch cut right
+    mod2pi(θ)
+end
 function tocanonical(d::Circle{T},ζ) where T<:Number
     v=mappoint(d,Circle(),ζ)
-    atan(imag(v)-0.0,real(v))  # -0.0 to get branch cut right
+	_tocanonical(reim(v))
 end
 
 function tocanonical(d::Circle{T},ζ) where T<:Vec
     v=mappoint(d,Circle((0.0,0.0),1.0),ζ)
-    atan(v[2]-0.0,v[1])  # -0.0 to get branch cut right
+	_tocanonical(v)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,6 +161,15 @@ end
 
     @test norm(ApproxFunBase.Reverse(Fourier())*Fun(t->cos(cos(t-0.2)-0.1),Fourier()) - Fun(t->cos(cos(-t-0.2)-0.1),Fourier())) < 10eps()
     @test norm(ApproxFunBase.ReverseOrientation(Fourier())*Fun(t->cos(cos(t-0.2)-0.1),Fourier()) - Fun(t->cos(cos(t-0.2)-0.1),Fourier(PeriodicSegment(2π,0)))) < 10eps()
+
+    @testset "issue #741" begin
+        c = Fun(cos, Fourier())
+        @test roots(c) ≈ (1:2:3) * pi/2
+        c = Fun(cos, Fourier(0..4pi))
+        @test roots(c) ≈ (1:2:7) * pi/2
+        c = Fun(cos, Fourier(-2pi..2pi))
+        @test roots(c) ≈ (-3:2:3) * pi/2
+    end
 end
 
 @testset "Laurent" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaApproximation/ApproxFun.jl/issues/741. Now
```julia
julia> c = Fun(cos, Fourier())
Fun(Fourier(【0.0,6.283185307179586❫), [-5.622629982202156e-17, 1.2537963267703604e-16, 1.0])

julia> roots(c)
2-element Vector{Float64}:
 1.570796326794897
 4.712388980384691
```