### PR TITLE
Conversion between Fourier spaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
       - 'LICENSE'
       - 'README.md'
       - '.github/workflows/TagBot.yml'
+
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     # continue-on-error: true # Uncomment once integration is finished

--- a/src/ApproxFunFourier.jl
+++ b/src/ApproxFunFourier.jl
@@ -42,9 +42,17 @@ import BandedMatrices: bandwidths
 import DomainSets: Domain, indomain, UnionDomain, Point, Interval,
             boundary, rightendpoint, leftendpoint, endpoints
 
-import Base: convert, getindex, *, +, -, ==,  /, eltype,
-            show, sum, cumsum, conj, issubset, first, last, rand, setdiff,
-            angle, isempty, zeros, one, promote_rule, real, imag, union
+import Base: values, convert, getindex, setindex!, *, +, -, ==, <, <=, >, |, !, !=, eltype, iterate,
+                >=, /, ^, \, ∪, transpose, size, tail, broadcast, broadcast!, copyto!, copy, to_index, (:),
+                similar, map, vcat, hcat, hvcat, show, summary, stride, sum, cumsum, conj, inv,
+                complex, reverse, exp, sqrt, abs, abs2, sign, issubset, in, first, last, rand, intersect, setdiff,
+                isless, union, angle, join, isnan, isapprox, isempty, sort, merge,
+                minimum, maximum, extrema, argmax, argmin, findmax, findmin, isfinite,
+                zeros, zero, one, promote_rule, repeat, length, resize!, isinf,
+                getproperty, findfirst, unsafe_getindex, fld, cld, div, real, imag,
+                @_inline_meta, eachindex, firstindex, lastindex, keys, isreal, OneTo,
+                Array, Vector, Matrix, view, ones, @propagate_inbounds, print_array,
+                split
 
 import LinearAlgebra: norm, mul!, isdiag
 
@@ -552,7 +560,7 @@ function domainsmultiple(A::Domain, B::Domain)
     return nothing
 end
 domainsmultiple(A::Space, B::Space) = domainsmultiple(map(domain, (A,B))...)
-function union_by_union_rule(A::Fourier, B::Fourier)
+function union(A::Fourier, B::Fourier)
     dA, dB = map(domain, (A,B))
     AB = domainsmultiple(dA, dB)
     isnothing(AB) || return Fourier(period(dA) > period(dB) ? dA : dB)

--- a/src/ApproxFunFourier.jl
+++ b/src/ApproxFunFourier.jl
@@ -42,13 +42,9 @@ import BandedMatrices: bandwidths
 import DomainSets: Domain, indomain, UnionDomain, Point, Interval,
             boundary, rightendpoint, leftendpoint, endpoints
 
-import Base: convert, getindex, *, +, -, ==, <, >, |, !, !=, eltype,
-                >=, /, ^, \, size, copyto!, copy, (:),
-                map, show, summary, sum, cumsum, conj, inv,
-                complex, reverse, exp, sqrt, abs, abs2, sign, issubset, in, first, last, rand, setdiff,
-                union, angle, isnan, isapprox, isempty, sort,
-                isfinite, zeros, zero, one, promote_rule, length, isinf,
-                div, real, imag, eachindex, isreal, Array, Vector, Matrix, view, ones
+import Base: convert, getindex, *, +, -, ==, /, eltype,
+            show, sum, conj, issubset, first, last, rand, setdiff,
+            union, angle, isempty, one, promote_rule, real, imag
 
 import LinearAlgebra: norm, mul!, isdiag
 

--- a/src/ApproxFunFourier.jl
+++ b/src/ApproxFunFourier.jl
@@ -42,17 +42,13 @@ import BandedMatrices: bandwidths
 import DomainSets: Domain, indomain, UnionDomain, Point, Interval,
             boundary, rightendpoint, leftendpoint, endpoints
 
-import Base: values, convert, getindex, setindex!, *, +, -, ==, <, <=, >, |, !, !=, eltype, iterate,
-                >=, /, ^, \, ∪, transpose, size, tail, broadcast, broadcast!, copyto!, copy, to_index, (:),
-                similar, map, vcat, hcat, hvcat, show, summary, stride, sum, cumsum, conj, inv,
-                complex, reverse, exp, sqrt, abs, abs2, sign, issubset, in, first, last, rand, intersect, setdiff,
-                isless, union, angle, join, isnan, isapprox, isempty, sort, merge,
-                minimum, maximum, extrema, argmax, argmin, findmax, findmin, isfinite,
-                zeros, zero, one, promote_rule, repeat, length, resize!, isinf,
-                getproperty, findfirst, unsafe_getindex, fld, cld, div, real, imag,
-                @_inline_meta, eachindex, firstindex, lastindex, keys, isreal, OneTo,
-                Array, Vector, Matrix, view, ones, @propagate_inbounds, print_array,
-                split
+import Base: convert, getindex, *, +, -, ==, <, >, |, !, !=, eltype,
+                >=, /, ^, \, size, copyto!, copy, (:),
+                map, show, summary, sum, cumsum, conj, inv,
+                complex, reverse, exp, sqrt, abs, abs2, sign, issubset, in, first, last, rand, setdiff,
+                union, angle, isnan, isapprox, isempty, sort,
+                isfinite, zeros, zero, one, promote_rule, length, isinf,
+                div, real, imag, eachindex, isreal, Array, Vector, Matrix, view, ones
 
 import LinearAlgebra: norm, mul!, isdiag
 

--- a/src/ApproxFunFourier.jl
+++ b/src/ApproxFunFourier.jl
@@ -566,14 +566,16 @@ function union(A::Fourier, B::Fourier)
     isnothing(AB) || return Fourier(period(dA) > period(dB) ? dA : dB)
     A ⊕ B
 end
+_ind(i, n) = 2n * div(i, 2) + isodd(i)
+_invind(i, n) = 2div(i - isodd(i), 2n) + isodd(i)
 function coefficients(v::AbstractVector, A::Fourier, B::Fourier)
     n = domainsmultiple(A, B)
     isnothing(n) && error("spaces are not compatible")
     n == 1 && return copy(v)
     if period(A) < period(B)
-        v2 = zeros(eltype(v), n * length(v) - isodd(length(v)))
+        v2 = zeros(eltype(v), _ind(length(v), n))
         for (i, vi) in enumerate(v)
-            v2[n * i - isodd(i)] = vi
+            v2[_ind(i, n)] = vi
         end
     else
         for (ind, vi) in enumerate(v)
@@ -581,9 +583,9 @@ function coefficients(v::AbstractVector, A::Fourier, B::Fourier)
                 throw(ArgumentError("coefficients incompatible with space conversion"))
             end
         end
-        v2 = zeros(eltype(v), div(length(v) + isodd(length(v)), n))
+        v2 = zeros(eltype(v), _invind(length(v), n))
         for i in eachindex(v2)
-            v2[i] = v[n * i - isodd(i)]
+            v2[i] = v[_ind(i, n)]
         end
     end
     return v2

--- a/src/ApproxFunFourier.jl
+++ b/src/ApproxFunFourier.jl
@@ -569,7 +569,7 @@ function coefficients(v::AbstractVector, A::Fourier, B::Fourier)
         end
     else
         for (ind, vi) in enumerate(v)
-            if isodd(div(ind, n, RoundDown)) && !isapprox(vi, 0, atol=eps(eltype(vi)))
+            if isodd(div(ind, n)) && !isapprox(vi, 0, atol=eps(eltype(vi)))
                 throw(ArgumentError("coefficients incompatible with space conversion"))
             end
         end

--- a/src/ApproxFunFourier.jl
+++ b/src/ApproxFunFourier.jl
@@ -540,18 +540,22 @@ function period(A::Domain)
 end
 function domainsmultiple(A::Domain, B::Domain)
     isapprox(A, B) && return 1
-    da = period(A)
-    db = period(B)
-    dmin, dmax = minmax(da, db)
+    la, ra = leftendpoint(A), rightendpoint(A)
+    lb, rb = leftendpoint(B), rightendpoint(B)
+    pa = ra - la
+    pb = rb - lb
+    dmin, dmax = minmax(pa, pb)
     T = promote_type(eltype(A), eltype(B))
-    isapprox(mod(dmax, dmin), 0, atol=eps(T)) && return round(Int, dmax/dmin, RoundNearest)
+    if isapprox(mod(dmax, dmin), 0, atol=eps(T)) && (la ≈ lb || ra ≈ rb)
+        return round(Int, dmax/dmin, RoundNearest)
+    end
     return nothing
 end
 domainsmultiple(A::Space, B::Space) = domainsmultiple(map(domain, (A,B))...)
 function union_by_union_rule(A::Fourier, B::Fourier)
     dA, dB = map(domain, (A,B))
     AB = domainsmultiple(dA, dB)
-    isnothing(AB) || return Fourier(max(dA, dB))
+    isnothing(AB) || return Fourier(period(dA) > period(dB) ? dA : dB)
     A ⊕ B
 end
 function coefficients(v::AbstractVector, A::Fourier, B::Fourier)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -213,7 +213,17 @@ end
         f2 = Fun(t->1+2sin(t)+3cos(t), Fourier(0..4pi))
         @test coefficients(coefficients(f1), space(f1), space(f2)) ≈ coefficients(f2)
         @test coefficients([1,0,0,2,3], Fourier(0..4pi), Fourier(0..2pi)) ≈ [1,2,3]
-        @test coefficients([1,2,3], Fourier(0..2pi), Fourier(0..4pi)) ≈ [1,0,0,2,3]
+        @test coefficients([1,2,3], Fourier(0..2pi), Fourier(0..4pi)) ≈ [1; zeros(2); [2,3]]
+        @test coefficients([1; zeros(2); [2,3]], Fourier(0..4pi), Fourier(0..2pi)) ≈ [1,2,3]
+        @test coefficients([4,1], Fourier(0..2pi), Fourier(0..4pi)) ≈ [4; zeros(2); 1]
+        @test coefficients([4,1], Fourier(0..2pi), Fourier(0..8pi)) ≈ [4; zeros(6); 1]
+        @test coefficients([4,1,2], Fourier(0..2pi), Fourier(0..4pi)) ≈ [4; zeros(2); [1, 2]]
+        @test coefficients([4,1,2], Fourier(0..2pi), Fourier(0..8pi)) ≈ [4; zeros(6); [1, 2]]
+        @test coefficients([4,1,2,3], Fourier(0..2pi), Fourier(0..4pi)) ≈ [4; zeros(2); [1, 2]; zeros(2); 3]
+        @test coefficients([4,1,2,3], Fourier(0..2pi), Fourier(0..6pi)) ≈ [4; zeros(4); [1, 2]; zeros(4); 3]
+        @test coefficients([4,1,2,3], Fourier(0..2pi), Fourier(0..8pi)) ≈ [4; zeros(6); [1, 2]; zeros(6); 3]
+        @test coefficients([4; zeros(4); [1, 2]; zeros(4); 3], Fourier(0..6pi), Fourier(0..2pi)) ≈ [4,1,2,3]
+        @test coefficients([4; zeros(6); [1, 2]; zeros(6); 3], Fourier(0..8pi), Fourier(0..2pi)) ≈ [4,1,2,3]
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,6 +206,19 @@ end
             g = f1 + f2
             @test g(pi/3) ≈ f1(pi/3) + f2(pi/3)
         end
+        f1 = Fun(sin, Fourier(0..2pi));
+        f2 = Fun(x->sin((2/3)x), Fourier(0..3pi));
+        g = f1 + f2
+        @test g.(pts) ≈ f1.(pts) .+ f2.(pts)
+        h = Fun(x-> sin(x)+sin(2*x/3),Fourier(0..6pi))
+        pts = [0:6;]*pi
+        @test g.(pts) ≈ h.(pts)
+
+        f1 = Fun(x->sin(2x), Fourier(pi..2pi))
+        f2 = Fun(x->sin(2x), Fourier(3pi..4pi))
+        g = f1 + f2
+        pts = [0:5;]*pi
+        @test g.(pts) ≈ f1.(pts) .+ f2.(pts)
     end
 
     @testset "coeff conversion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,13 +188,24 @@ end
     @test norm(ApproxFunBase.Reverse(Fourier())*Fun(t->cos(cos(t-0.2)-0.1),Fourier()) - Fun(t->cos(cos(-t-0.2)-0.1),Fourier())) < 10eps()
     @test norm(ApproxFunBase.ReverseOrientation(Fourier())*Fun(t->cos(cos(t-0.2)-0.1),Fourier()) - Fun(t->cos(cos(t-0.2)-0.1),Fourier(PeriodicSegment(2π,0)))) < 10eps()
 
-    @testset "issue #741" begin
+    @testset "ApproxFun issue #741" begin
         c = Fun(cos, Fourier())
         @test roots(c) ≈ (1:2:3) * pi/2
         c = Fun(cos, Fourier(0..4pi))
         @test roots(c) ≈ (1:2:7) * pi/2
         c = Fun(cos, Fourier(-2pi..2pi))
         @test roots(c) ≈ (-3:2:3) * pi/2
+    end
+
+    @testset "ApproxFun issue #768" begin
+        s1 = Fourier(0..pi)
+        f1 = Fun(t -> sin(2*t),s1)
+        @testset for d2 in [0..2pi, 0..3pi]
+            s2 = Fourier(d2)
+            f2 = Fun(t -> sin(2*t),s2)
+            g = f1 + f2
+            @test g(pi/3) ≈ f1(pi/3) + f2(pi/3)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,9 +209,15 @@ end
     end
 
     @testset "coeff conversion" begin
-        f1 = Fun(t->1+2sin(t)+3cos(t), Fourier(0..2pi))
-        f2 = Fun(t->1+2sin(t)+3cos(t), Fourier(0..4pi))
+        f = t->1+2sin(t)+3cos(t)
+        f1 = Fun(f, Fourier(0..2pi))
+
+        f2 = Fun(f, Fourier(0..4pi))
         @test coefficients(coefficients(f1), space(f1), space(f2)) ≈ coefficients(f2)
+
+        f3 = Fun(f, Fourier(0..8pi))
+        @test coefficients(coefficients(f1), space(f1), space(f3)) ≈ coefficients(f3)
+
         @test coefficients([1,0,0,2,3], Fourier(0..4pi), Fourier(0..2pi)) ≈ [1,2,3]
         @test coefficients([1,2,3], Fourier(0..2pi), Fourier(0..4pi)) ≈ [1; zeros(2); [2,3]]
         @test coefficients([1; zeros(2); [2,3]], Fourier(0..4pi), Fourier(0..2pi)) ≈ [1,2,3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,14 @@ end
             @test g(pi/3) ≈ f1(pi/3) + f2(pi/3)
         end
     end
+
+    @testset "coeff conversion" begin
+        f1 = Fun(t->1+2sin(t)+3cos(t), Fourier(0..2pi))
+        f2 = Fun(t->1+2sin(t)+3cos(t), Fourier(0..4pi))
+        @test coefficients(coefficients(f1), space(f1), space(f2)) ≈ coefficients(f2)
+        @test coefficients([1,0,0,2,3], Fourier(0..4pi), Fourier(0..2pi)) ≈ [1,2,3]
+        @test coefficients([1,2,3], Fourier(0..2pi), Fourier(0..4pi)) ≈ [1,0,0,2,3]
+    end
 end
 
 @testset "Laurent" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,9 +209,9 @@ end
         f1 = Fun(sin, Fourier(0..2pi));
         f2 = Fun(x->sin((2/3)x), Fourier(0..3pi));
         g = f1 + f2
+        pts = [0:6;]*pi
         @test g.(pts) ≈ f1.(pts) .+ f2.(pts)
         h = Fun(x-> sin(x)+sin(2*x/3),Fourier(0..6pi))
-        pts = [0:6;]*pi
         @test g.(pts) ≈ h.(pts)
 
         f1 = Fun(x->sin(2x), Fourier(pi..2pi))


### PR DESCRIPTION
Fixes https://github.com/JuliaApproximation/ApproxFun.jl/issues/768. After this, the following works:
```julia
julia> coefficients([1,2,3], Fourier(0..2pi), Fourier(0..4pi))
5-element Vector{Int64}:
 1
 0
 0
 2
 3

julia> union(Fourier(0..2pi), Fourier(0..4pi))
Fourier(【0.0,12.566370614359172❫)

julia> union(Fourier(0..2pi), Fourier(0..3pi))
Fourier(【0.0,6.283185307179586❫)⨄Fourier(【0.0,9.42477796076938❫)
```
WIP to allow domains that aren't multiples of each other.