### PR TITLE
move show methods from ApproxFun

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunFourier"
 uuid = "59844689-9c9d-51bf-9583-5b794ec66d30"
-version = "0.2.15"
+version = "0.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunFourier"
 uuid = "59844689-9c9d-51bf-9583-5b794ec66d30"
-version = "0.3"
+version = "0.3.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ApproxFunFourier.jl
+++ b/src/ApproxFunFourier.jl
@@ -613,5 +613,19 @@ function Fun(T::ToeplitzOperator)
      end
  end
 
+Base.show(io::IO,d::Circle) =
+    print(io,(d.radius==1 ? "" : string(d.radius))*
+                    (d.orientation ? "🕒" : "🕞")*
+                    (d.center==0 ? "" : "+$(d.center)"))
+
+Base.show(io::IO, d::PeriodicSegment) = print(io,"【$(leftendpoint(d)),$(rightendpoint(d))❫")
+for typ in (:Fourier, :Laurent, :Taylor, :SinSpace, :CosSpace)
+    typstr = string(typ)
+    @eval function Base.show(io::IO, S::$typ)
+        print(io, $typstr, "(")
+        show(io, domain(S))
+        print(io, ")")
+    end
+end
 
 end #module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -603,11 +603,11 @@ end
             (SinSpace, "SinSpace"), (Laurent, "Laurent"), (Taylor, "Taylor")]
         sp = spT()
         str = repr(sp)
-        @test contains(str, spstr)
+        @test occursin(spstr, str)
         d = domain(sp)
         if d isa ApproxFunFourier.PeriodicSegment
-            @test contains(str, repr(leftendpoint(d)))
-            @test contains(str, repr(rightendpoint(d)))
+            @test occursin(repr(leftendpoint(d)), str)
+            @test occursin(repr(rightendpoint(d)), str)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -597,3 +597,17 @@ end
     f=Fun(z->2exp(z^2),PeriodicLine(0.,π/2))
     @test f(1.1im) ≈ 2exp(-1.1^2)
 end
+
+@testset "show" begin
+    for (spT, spstr) in Any[(Fourier, "Fourier"), (CosSpace, "CosSpace"),
+            (SinSpace, "SinSpace"), (Laurent, "Laurent"), (Taylor, "Taylor")]
+        sp = spT()
+        str = repr(sp)
+        @test contains(str, spstr)
+        d = domain(sp)
+        if d isa ApproxFunFourier.PeriodicSegment
+            @test contains(str, repr(leftendpoint(d)))
+            @test contains(str, repr(rightendpoint(d)))
+        end
+    end
+end


### PR DESCRIPTION
This improves the display in this package, and reduces type-piracy in `ApproxFun`