### PR TITLE
don't test for undef exports

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using Test
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(ApproxFunFourier, ambiguities=false, undefined_exports=(VERSION > v"1.5" #= Requires ApproxFunBase v0.7 =#))
+    Aqua.test_all(ApproxFunFourier, ambiguities=false, undefined_exports=false)
 end
 
 @testset "Periodic Domains" begin


### PR DESCRIPTION
Checking for undefined exports requires ApproxFunBase v0.7. In the next release, we will drop support for older versions and reintroduce the test.