### PR TITLE
Ignore ApproxFunBaseTest as a dep

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,8 @@ using Test
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(ApproxFunFourier, ambiguities=false)
+    Aqua.test_all(ApproxFunFourier, ambiguities=false,
+        stale_deps=(; ignore=[:ApproxFunBaseTest]))
 end
 
 @testset "Periodic Domains" begin


### PR DESCRIPTION
This lets one carry out downstream tests in ApproxFunBaseTest by developing the package, without being flagged by Aqua.