### PR TITLE
Forward spaces to wrapper types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 AbstractFFTs = "0.5, 1"
-ApproxFunBase = "0.7.54, 0.8"
+ApproxFunBase = "0.8"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"

--- a/src/FourierOperators.jl
+++ b/src/FourierOperators.jl
@@ -140,7 +140,9 @@ end
 function Derivative(S::Fourier{<:Circle}, k::Number)
     assert_integer(k)
     @assert k > 0 "order of derivative must be > 0"
-    DerivativeWrapper(Derivative(Laurent(S),k)*Conversion(S,Laurent(S)),k)
+    DerivOp = Derivative(Laurent(S),k)
+    ConvertOp = Conversion(S,Laurent(S))
+    DerivativeWrapper(DerivOp * ConvertOp, k, S, rangespace(DerivOp))
 end
 
 Integral(::CosSpace, m::Number) =

--- a/src/LaurentOperators.jl
+++ b/src/LaurentOperators.jl
@@ -189,7 +189,9 @@ function Integral(S::SubSpace{<:Hardy{false,<:Circle}, <:AbstractInfUnitRange{In
     else
         @assert first(S.index) > k+1
         S2=S.space|(k+1:∞)
-        IntegralWrapper(ConcreteIntegral(S2,k)*Converion(S,S2),k)
+        Integralop = ConcreteIntegral(S2,k)
+        ConvertOp = Converion(S,S2)
+        IntegralWrapper(Integralop * ConvertOp, k, S, rangespace(Integralop))
     end
 end
 


### PR DESCRIPTION
This relies on ApproxFunBase v0.8's newly introduced feature to allow spaces to be forwarded to the wrapper types, instead of being inferred from the parent. This might help with type inference (although it doesn't at present).