### PR TITLE
Diagonal interlace in Laurent(Circle()) Derivative

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunFourier"
 uuid = "59844689-9c9d-51bf-9583-5b794ec66d30"
-version = "0.3.13"
+version = "0.3.14"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -17,7 +17,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 AbstractFFTs = "0.5, 1"
-ApproxFunBase = "0.8"
+ApproxFunBase = "0.8.6"
 ApproxFunBaseTest = "0.1"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"

--- a/src/ApproxFunFourier.jl
+++ b/src/ApproxFunFourier.jl
@@ -35,7 +35,7 @@ import ApproxFunBase: Fun, SumSpace, SubSpace, NoSpace, IntervalOrSegment,
             reverseeven!, negateeven!, cfstype, alternatesign!, extremal_args,
             hesseneigvals, chebyshev_clenshaw, roots, EmptyDomain,
             chebmult_getindex, components, affine_setdiff, complexroots,
-            assert_integer, companion_matrix
+            assert_integer, companion_matrix, InterlaceOperator_Diagonal
 
 import BandedMatrices: bandwidths
 

--- a/src/Domains/Circle.jl
+++ b/src/Domains/Circle.jl
@@ -60,9 +60,9 @@ end
 orientationsign(d::Circle) = d.orientation ? 1 : -1
 
 fromcanonical(d::Circle{T,V,Complex{V}},θ) where {T<:Number,V<:Real} =
-	d.radius * cis(orientationsign(d) * θ) + d.center
+	d.radius * exp(orientationsign(d) * 1.0im * θ) + d.center
 fromcanonicalD(d::Circle{T},θ) where {T<:Number} =
-	orientationsign(d) * d.radius * 1.0im * cis(orientationsign(d) * θ)
+	orientationsign(d) * d.radius * 1.0im * exp(orientationsign(d) * 1.0im * θ)
 
 
 fromcanonical(d::Circle{T},θ::Number) where {T<:SVector} =

--- a/src/FourierOperators.jl
+++ b/src/FourierOperators.jl
@@ -84,10 +84,9 @@ getindex(C::ConcreteConversion{Fourier{DD,R1},Fourier{DD,R2},T},k::Integer,j::In
 
 
 ### Cos/Sine
-
-
-function Derivative(S::Union{CosSpace,SinSpace},order)
-    @assert isa(domain(S),PeriodicSegment)
+function Derivative(S::Union{CosSpace,SinSpace}, order::Number)
+    assert_integer(order)
+    @assert isa(domain(S), PeriodicSegment)
     @assert order > 0 "order of derivative must be > 0"
     ConcreteDerivative(S,order)
 end

--- a/src/LaurentOperators.jl
+++ b/src/LaurentOperators.jl
@@ -81,9 +81,7 @@ function Derivative(S::Laurent{<:Circle}, k::Number)
     assert_integer(k)
     @assert k > 0 " order of derivative must be > 0"
     t = map(s->Derivative(s,k), S.spaces)
-    v = convert_vector_or_svector(t)
-    D = Diagonal(v)
-    O = InterlaceOperator(D, SumSpace)
+    O = InterlaceOperator_Diagonal(t, S)
     DerivativeWrapper(O,k)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,7 +212,7 @@ end
     @test B*Fun(sin,domainspace(B)) ≈ 1.0
 
     ## Diagonal Derivative
-    D = Derivative(Laurent())
+    D = @inferred Derivative(Laurent())
     @test isdiag(D)
 end
 
@@ -289,6 +289,8 @@ end
     ## Test bug in multiplication
     y = Fun(Circle())
     @test (y^2) ≈ Fun(z->z^2,domain(y))
+
+    @inferred Derivative(Laurent(Circle()))
 end
 
 


### PR DESCRIPTION
This makes `Derivative(Laurent(Circle()))` type-inferred:
```julia
julia> @inferred Derivative(Laurent(Circle()))
DerivativeWrapper : Laurent(🕒) → Laurent(🕒)
 0.0+0.0im   0.0+0.0im  1.0+0.0im       ⋅          ⋅           ⋅          ⋅           ⋅          ⋅          ⋅      ⋅
 0.0+0.0im   0.0+0.0im  0.0+0.0im   0.0+0.0im      ⋅           ⋅          ⋅           ⋅          ⋅          ⋅      ⋅
 0.0+0.0im   0.0+0.0im  0.0+0.0im   0.0+0.0im  2.0+0.0im       ⋅          ⋅           ⋅          ⋅          ⋅      ⋅
     ⋅      -1.0+0.0im  0.0+0.0im   0.0+0.0im  0.0+0.0im   0.0+0.0im      ⋅           ⋅          ⋅          ⋅      ⋅
     ⋅           ⋅      0.0+0.0im   0.0+0.0im  0.0+0.0im   0.0+0.0im  3.0+0.0im       ⋅          ⋅          ⋅      ⋅
     ⋅           ⋅          ⋅      -2.0+0.0im  0.0+0.0im   0.0+0.0im  0.0+0.0im   0.0+0.0im      ⋅          ⋅      ⋅
     ⋅           ⋅          ⋅           ⋅      0.0+0.0im   0.0+0.0im  0.0+0.0im   0.0+0.0im  4.0+0.0im      ⋅      ⋅
     ⋅           ⋅          ⋅           ⋅          ⋅      -3.0+0.0im  0.0+0.0im   0.0+0.0im  0.0+0.0im  0.0+0.0im  ⋅
     ⋅           ⋅          ⋅           ⋅          ⋅           ⋅      0.0+0.0im   0.0+0.0im  0.0+0.0im  0.0+0.0im  ⋱
     ⋅           ⋅          ⋅           ⋅          ⋅           ⋅          ⋅      -4.0+0.0im  0.0+0.0im  0.0+0.0im  ⋱
     ⋅           ⋅          ⋅           ⋅          ⋅           ⋅          ⋅           ⋅          ⋱          ⋱      ⋱
```