### PR TITLE
type inference improvements in CosSpace/Fourier integrate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 AbstractFFTs = "0.5, 1"
 ApproxFunBase = "0.8.6"
 ApproxFunBaseTest = "0.1"
+ApproxFunOrthogonalPolynomials = "0.6"
 Aqua = "0.5"
 BandedMatrices = "0.16, 0.17"
 DomainSets = "0.3, 0.4, 0.5, 0.6"
@@ -33,9 +34,10 @@ julia = "1.6"
 
 [extras]
 ApproxFunBaseTest = "a931bfaf-0cfd-4a5c-b69c-bf2eed002b43"
+ApproxFunOrthogonalPolynomials = "b70543e2-c0d9-56b8-a290-0d4d6d4de211"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ApproxFunBaseTest", "Aqua", "Test", "SpecialFunctions"]
+test = ["ApproxFunBaseTest", "ApproxFunOrthogonalPolynomials", "Aqua", "Test", "SpecialFunctions"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -299,6 +299,7 @@ end
                 Fun(θ->sin(sin(θ)),Fourier()),Fun(θ->cos(θ)+cos(3θ),CosSpace()))
         @test norm(integrate(f)'-f)<10eps()
     end
+    @test iszero(integrate(Fun(CosSpace(), Float64[])))
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using ApproxFunBase: Block, EmptyDomain, UnionDomain
 using ApproxFunBaseTest: testspace, testtransforms, testmultiplication, testraggedbelowoperator,
                     testbandedoperator, testblockbandedoperator, testbandedblockbandedoperator,
                     testcalculus, testfunctional
+using ApproxFunOrthogonalPolynomials
 using LinearAlgebra
 using SpecialFunctions
 _factorial(n) = gamma(n+1)
@@ -300,6 +301,11 @@ end
         @test norm(integrate(f)'-f)<10eps()
     end
     @test iszero(integrate(Fun(CosSpace(), Float64[])))
+    f = Fun(θ->1+cos(θ), CosSpace())
+    g = integrate(f)
+    θ = 0.4
+    @test g(θ) ≈ θ + sin(θ)
+    @test Fun(g', space(f)) ≈ f
 end
 
 


### PR DESCRIPTION
With this, the type of the integral of a `Fun` in `CosSpace` or `Fourier` is inferred to be a small `Union` of concrete types. We simply bypass calling `⊕` and directly construct the `SumSpace`, since we know that the domains are identical in this case (there is only one domain).

Also, fixes
```julia
julia> integrate(Fun(CosSpace(), Float64[]))
Fun(SinSpace(【0.0,6.283185307179586❫), Float64[])
```