### PR TITLE
Speed-up `Fourier` `Evaluation` indexing

### DIFF
--- a/src/FourierOperators.jl
+++ b/src/FourierOperators.jl
@@ -397,13 +397,15 @@ function _conceval(C, ::Fourier, order, x, m, k)
     end
     convert(eltype(C), t)
 end
+neg1pow(x) = (-1)^x
+neg1pow(x::Integer) = iseven(x) ? 1 : -1
 function getindex(C::ConcreteEvaluation{<:Fourier{<:PeriodicSegment}}, k::Integer)
     m = k ÷ 2
     order = C.order
     L = period(domain(C))
     t = _conceval(C, domainspace(C), C.order, evaluation_point(C), m, k)
     # s = (-1)^((order + isodd(k))÷2) # faster implementation below
-    s = trailing_zeros(order + k) == 0 ? 1 : -1
+    s = neg1pow((order + isodd(k)) ÷ 2)
     r = s * (m * 2pi/L)^order * t
     convert(eltype(C), r)
 end

--- a/src/FourierOperators.jl
+++ b/src/FourierOperators.jl
@@ -402,7 +402,8 @@ function getindex(C::ConcreteEvaluation{<:Fourier{<:PeriodicSegment}}, k::Intege
     order = C.order
     L = period(domain(C))
     t = _conceval(C, domainspace(C), C.order, evaluation_point(C), m, k)
-    s = (-1)^((order + isodd(k))÷2)
+    # s = (-1)^((order + isodd(k))÷2) # faster implementation below
+    s = trailing_zeros(order + k) == 0 ? 1 : -1
     r = s * (m * 2pi/L)^order * t
     convert(eltype(C), r)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,10 @@ using Aqua
         stale_deps=(; ignore=[:ApproxFunBaseTest]))
 end
 
+@testset "utils" begin
+    @test ApproxFunFourier.neg1pow(1.0) ≈ ApproxFunFourier.neg1pow(1)
+end
+
 @testset "Periodic Domains" begin
     @test 0.1 ∈ PeriodicSegment(2π,0)
     @test 100.0 ∈ PeriodicSegment(0,2π)


### PR DESCRIPTION
On master
```julia
julia> @btime Evaluation(Fourier(), leftendpoint)[1:100];
  1.594 μs (7 allocations: 1.11 KiB)
```
This PR
```julia
julia> @btime Evaluation(Fourier(), leftendpoint)[1:100];
  1.380 μs (7 allocations: 1.11 KiB)
```