### PR TITLE
Fix for issue #125 for real numbers

### DIFF
--- a/src/Domains/PeriodicSegment.jl
+++ b/src/Domains/PeriodicSegment.jl
@@ -102,7 +102,7 @@ function convert(::Type{PeriodicDomain},d::ClosedInterval)
     end
 end
 
-indomain(x::R1, d::PeriodicSegment{R2}) where {R1<:Real,R2<:Real} = true
+indomain(x::R1, d::PeriodicSegment{R2}) where {R1<:Real,R2<:Real} = isfinite(x)
 issubset(a::PeriodicSegment, b::IntervalOrSegment) = Segment(endpoints(a)...)⊆b
 issubset(a::IntervalOrSegment, b::PeriodicSegment) = PeriodicSegment(endpoints(a)...)⊆b
 

--- a/src/Domains/PeriodicSegment.jl
+++ b/src/Domains/PeriodicSegment.jl
@@ -72,9 +72,6 @@ reverseorientation(d::PeriodicSegment) = PeriodicSegment(rightendpoint(d), lefte
 ==(d::PeriodicSegment,m::PeriodicSegment) = leftendpoint(d) == m.a && rightendpoint(d) == m.b
 
 
-
-
-
 ## algebra
 
 for op in (:*,:+,:-)
@@ -105,6 +102,7 @@ function convert(::Type{PeriodicDomain},d::ClosedInterval)
     end
 end
 
+indomain(x::R1, d::PeriodicSegment{R2}) where {R1<:Real,R2<:Real} = true
 issubset(a::PeriodicSegment, b::IntervalOrSegment) = Segment(endpoints(a)...)⊆b
 issubset(a::IntervalOrSegment, b::PeriodicSegment) = PeriodicSegment(endpoints(a)...)⊆b
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,10 +27,14 @@ end
     @test 0.1 ∈ PeriodicSegment(2π,0)
     @test 100.0 ∈ PeriodicSegment(0,2π)
     @test -100.0 ∈ PeriodicSegment(0,2π)
+    @test 0 ∈ PeriodicSegment(-2,3)  #issue 125
+    @test 1e-15 ∈ PeriodicSegment(-2,3) #issue 125
 
-    @test 10.0 ∈ PeriodicLine()
+    @test 10.0 ∈ PeriodicLine() 
     @test -10.0 ∈ PeriodicLine()
     @test -10.0+im ∉ PeriodicLine()
+    @test 0 ∈ PeriodicLine() #issue 125
+    @test 1e-15 ∈ PeriodicLine() #issue 125
 
     p = PeriodicSegment(0,2π)
     @test leftendpoint(p) == 0


### PR DESCRIPTION
This fixes issue #125, for real `PeriodicSegment` and real values `x`. It overloads
```
indomain(x::R1, d::PeriodicSegment{R2}) where {R1<:Real,R2<:Real} = true
```
I also added some testcases.

For all other types of numbers (e.g. `ComplexF64`) or all other PeriodicDomains the old definition still applies, and so issue #125 is potentially still not resolved for them.

